### PR TITLE
Rewrite mm-combine-tunnel-logs

### DIFF
--- a/src/frontend/tunnelservershell.cc
+++ b/src/frontend/tunnelservershell.cc
@@ -82,7 +82,11 @@ int main( int argc, char *argv[] )
         AutoconnectSocket listening_socket;
         /* bind the listening socket to an available address/port, and print out what was bound */
         listening_socket.bind( Address() );
-        cout << "mm-tunnelclient localhost " << listening_socket.local_address().port() << " " << client_private_address.ip() << " " << local_private_address.ip() << endl;
+        cout << "mm-tunnelclient localhost " << listening_socket.local_address().port() << " ";
+        cout << client_private_address.ip() << " " << local_private_address.ip();
+        cout << " --ingress-log=/tmp/tunnelclient.ingress.log";
+        cout << " --egress-log=/tmp/tunnelclient.egress.log";
+        cout << endl;
 
         TunnelShell tunnelserver( ingress_logfile, egress_logfile );
 


### PR DESCRIPTION
Major changes:
1. Generate the output log based on the order of received_packets_log
for efficiency reasons.
2. Each line in the output log contains the timestamp on the receiver
side, received packet size and one way delay. Remove the size of sent
packet since it is not the real packet departure opportunity, which
is actually unknown to mm-tunnelclient or mm-tunnelserver.
3. Passed PEP8 check.